### PR TITLE
Feature/reservation controller endpoints

### DIFF
--- a/app/controllers/api/v1/reservations_controller.rb
+++ b/app/controllers/api/v1/reservations_controller.rb
@@ -1,0 +1,53 @@
+class Api::V1::ReservationsController < ApplicationController
+  before_action :set_reservation, only: %i[show update destroy]
+
+  before_action :authenticate_user
+
+  # GET /reservations
+  def index
+    @reservations = Reservation.all
+    render json: @reservations
+  end
+
+  # GET /reservations/1
+  def show
+    render json: @reservation
+  end
+
+  # POST /reservations
+  def create
+    @reservation = @current_user.reservation.new(reservation_params)
+
+    if @reservation.save
+      render json: @reservation, status: :created
+    else
+      render json: @reservation.errors, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH/PUT /reservations/1
+  def update
+    if @reservation.update(reservation_params)
+      render json: @reservation
+    else
+      render json: @reservation.errors, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /reservations/1
+  def destroy
+    @reservation.destroy
+  end
+
+  private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_reservation
+    @reservation = Reservation.find(params[:id])
+  end
+
+  # Only allow a list of trusted parameters through.
+  def reservation_params
+    params.require(:reservation).permit(:start_date, :end_date, :guests, :property_id)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
       resources :reservation_criterias, only: %i[index show create update destroy]
       resources :addresses, only: %i[create update destroy]
       resources :users, only: %i[index show update destroy]
+      resources :reservations, only: %i[index show create update destroy]
       post 'auth/sign_in', to: 'authentication#sign_in'
       post 'auth/sign_up', to: 'users#create'
       get 'auth/me', to: 'authentication#current_user'

--- a/spec/controller/api/v1/reservations_controller_spec.rb
+++ b/spec/controller/api/v1/reservations_controller_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+require 'faker'
+
+RSpec.describe Api::V1::ReservationsController, type: :controller do
+  before do
+    User.delete_all
+    Property.delete_all
+    ReservationCriteria.delete_all
+    Reservation.delete_all
+
+    @user1 = User.create!(name: Faker::Name.name, email: Faker::Internet.email, password: 'password',
+                          password_confirmation: 'password', avatar: Faker::LoremFlickr.image)
+    @category1 = Category.create!(name: Faker::Lorem.word)
+    @property1 = Property.create!(name: Faker::Lorem.word, description: Faker::Lorem.sentence, no_bedrooms: 2,
+                                  no_baths: 2, no_beds: 2, area: 100.0, user: @user1, category: @category1)
+    @criteria = ReservationCriteria.create!(time_period: 'weekly', others_fee: 100, rate: 10, min_time_period: 3,
+                                            max_guest: 10, property: @property1)
+    @overlapping_reservation = Reservation.create!(start_date: Date.today + 11, end_date: Date.today + 15, guests: 5,
+                                                   user: @user1, property: @property1)
+  end
+
+  describe 'POST #create' do
+    context 'when user is authenticated with valid parameters' do
+      before do
+        sign_in(@user1)
+      end
+
+      let(:valid_params) do
+        {
+          reservation: {
+            start_date: '2023-05-20',
+            end_date: '2023-05-25',
+            guests: 2,
+            property_id: @property1.id
+          }
+        }
+      end
+
+      it 'creates a new reservation' do
+        expect do
+          post :create, params: valid_params
+        end.to change(Reservation, :count).by(1)
+      end
+
+      it 'returns a success response with the created reservation' do
+        post :create, params: valid_params
+        expect(response).to have_http_status(:created)
+
+        reservation = Reservation.last
+        expect(response.body).to eq(reservation.to_json)
+      end
+    end
+
+    context 'when user is authenticated with invalid parameters' do
+      before do
+        sign_in(@user1)
+      end
+
+      let(:invalid_params) do
+        {
+          reservation: {
+            start_date: '2023-05-18',
+            end_date: '2023-05-15',
+            guests: -1,
+            property_id: nil
+          }
+        }
+      end
+
+      it 'does not create a new reservation' do
+        expect do
+          post :create, params: invalid_params
+        end.not_to change(Reservation, :count)
+      end
+
+      it 'returns an unprocessable_entity response with the reservation errors' do
+        post :create, params: invalid_params
+        expect(response).to have_http_status(:unprocessable_entity)
+
+        errors = JSON.parse(response.body)
+        puts errors
+        expect(errors.keys).to contain_exactly('property', 'end_date')
+      end
+    end
+
+    context 'when user is not authenticated' do
+      it 'returns an unauthorized response' do
+        post :create, params: { reservation: {} }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Rent Home Now API: Add Reservation Controller #10 

### Project Requirement

- Create routes for reservations
  - `/api/v1/reservations`
  - for reservations
    - required `start_date`, `end_date`, `property_id,` `guests` attributes
    - require Authorization header token
- Add The Reservations Controler for each operation:
  - Add #index method
  - Add the #show method
  - Add the #create method
  - Add #update method
  - Add #destroy method
- Add test cases for reservations controller

### General requirements

- There are [no linter errors](https://github.com/microverseinc/linters-config).
- I used the correct flow [Gitflow](https://github.com/microverseinc/curriculum-transversal-skills/blob/main/git-github/articles/gitflow.md).
- I documented the Readme file [in a professional way](https://github.com/microverseinc/curriculum-transversal-skills/blob/main/documentation/articles/professional_repo_rules.md).
- Follow the list of [best practices for Ruby](https://github.com/microverseinc/curriculum-ruby/blob/main/articles/ruby_best_practices.md).